### PR TITLE
Remove hacky closure modification

### DIFF
--- a/Cask
+++ b/Cask
@@ -1,0 +1,7 @@
+(source gnu)
+(source melpa)
+
+(package-file "with-simulated-input.el")
+
+(development
+ (depends-on "buttercup"))

--- a/tests/test-with-simulated-input.el
+++ b/tests/test-with-simulated-input.el
@@ -122,6 +122,16 @@
            (read-string "Say hello: "))
          :to-equal "hello world")))
 
+    (it "should allow a variable for KEYS"
+      (let ((keys "hello RET"))
+        (expect (with-simulated-input keys (read-string "Say hello: "))
+                :to-equal "hello")))
+
+    (it "should error for non-string variable KEYS"
+      (let ((keys (lambda () (insert "X"))))
+        (expect (with-simulated-input keys (read-string "Input: "))
+                :to-throw)))
+
     (it "should allow lisp forms to throw errors"
       (expect
 

--- a/tests/test-with-simulated-input.el
+++ b/tests/test-with-simulated-input.el
@@ -157,18 +157,7 @@
             (read-string "Enter a string: "))
          nil)
         (expect my-non-lexical-var
-                :to-be-truthy)))
-
-    (it "should allow interpolation of variables into KEYS"
-      (let ((my-key-sequence "hello")
-            (my-lisp-form '(insert " world")))
-        (expect
-         (with-simulated-input (list
-                                my-key-sequence
-                                my-lisp-form
-                                "RET")
-           (read-string "Enter a string: "))
-         :to-equal "hello world")))))
+                :to-be-truthy)))))
 
 (defun time-equal-p (t1 t2)
   "Return non-nil if T1 and T2 represent the same time.

--- a/tests/test-with-simulated-input.el
+++ b/tests/test-with-simulated-input.el
@@ -118,7 +118,7 @@
       (let ((greeting "hello")
             (target "world"))
         (expect
-         (with-simulated-input '(greeting "SPC" (insert target) "RET")
+         (with-simulated-input '((insert greeting) "SPC" (insert target) "RET")
            (read-string "Say hello: "))
          :to-equal "hello world")))
 

--- a/tests/test-with-simulated-input.el
+++ b/tests/test-with-simulated-input.el
@@ -1,7 +1,7 @@
 ;;; -*- lexical-binding: t -*-
 
-(require 'undercover)
-(undercover "with-simulated-input.el")
+(when (require 'undercover nil t)
+  (undercover "with-simulated-input.el"))
 
 (require 'with-simulated-input)
 (require 'cl-lib)

--- a/tests/test-with-simulated-input.el
+++ b/tests/test-with-simulated-input.el
@@ -118,10 +118,7 @@
       (let ((greeting "hello")
             (target "world"))
         (expect
-         (with-simulated-input
-             (list greeting "SPC"
-                   (list 'insert target)
-                   "RET")
+         (with-simulated-input (greeting "SPC" (insert target) "RET")
            (read-string "Say hello: "))
          :to-equal "hello world")))
 

--- a/tests/test-with-simulated-input.el
+++ b/tests/test-with-simulated-input.el
@@ -118,7 +118,7 @@
       (let ((greeting "hello")
             (target "world"))
         (expect
-         (with-simulated-input (greeting "SPC" (insert target) "RET")
+         (with-simulated-input '(greeting "SPC" (insert target) "RET")
            (read-string "Say hello: "))
          :to-equal "hello world")))
 

--- a/with-simulated-input.el
+++ b/with-simulated-input.el
@@ -3,7 +3,9 @@
 ;; Copyright (C) 2017 Ryan C. Thompson
 
 ;; Filename: with-simulated-input.el
-;; Author: Ryan C. Thompson
+;; Maintainer: Ryan C Thompson <rct@thompsonclan.org>
+;; Author: Ryan C. Thompson <rct@thompsonclan.org>
+;;    Nikita Bloshchanevich <nikblos@outlook.com>
 ;; Created: Thu Jul 20 11:56:23 2017 (-0700)
 ;; Version: 2.4
 ;; Package-Requires: ((emacs "24.4"))

--- a/with-simulated-input.el
+++ b/with-simulated-input.el
@@ -173,12 +173,19 @@ are propagated normally.
 The return value is the last form in BODY, as if it was wrapped
 in `progn'."
   (declare (indent 1) (debug ([&or ("quote" (&rest &or stringp def-form))
+                                   ("list" [&rest &or stringp ("quote" def-form)])
                                    (&rest &or stringp def-form)
                                    stringp]
                               def-body)))
   (pcase keys
     (`(quote ,x) (setq keys x))
-    ((guard (not (listp keys))) (cl-callf list keys)))
+    ((guard (not (listp keys))) (cl-callf list keys))
+    ((guard (eq 'list (car keys)))
+     (cl-loop for key in (cdr keys) collect
+              (pcase key
+                (`(quote ,x) x)
+                (_ key))
+              into new-keys finally do (setq keys new-keys))))
   `(with-simulated-input--1
     (lambda ()
       ,@body)

--- a/with-simulated-input.el
+++ b/with-simulated-input.el
@@ -82,8 +82,7 @@ modifier combinations, e.g.:
     '(\"C-\" \"M-\" \"C-M-\")
 
 for control, meta, or both. KEYS is a string containing all keys
-to check.
-"
+to check."
   (declare (advertised-calling-convention (&optional modifiers keys) nil))
   (when (stringp modifiers)
     (setq modifiers (list modifiers)))
@@ -198,7 +197,10 @@ set to 5 seconds, then 10 seconds the next time, and so on.")
   "Return the faked value while simulating idle time.
 
 While executing `wsi-simulate-idle-time', this advice causes the
-simulated idle time to be returned instead of the real value."
+simulated idle time to be returned instead of the real value.
+
+ORIG-FUN is the original function, passed by `advice-add'; ARGS
+are the arguments given to it."
   (if wsi-simulated-idle-time
       (when (time-less-p (seconds-to-time 0) wsi-simulated-idle-time)
         wsi-simulated-idle-time)

--- a/with-simulated-input.el
+++ b/with-simulated-input.el
@@ -5,7 +5,7 @@
 ;; Filename: with-simulated-input.el
 ;; Author: Ryan C. Thompson
 ;; Created: Thu Jul 20 11:56:23 2017 (-0700)
-;; Version: 3.4
+;; Version: 2.4
 ;; Package-Requires: ((emacs "24.4"))
 ;; URL: https://github.com/DarwinAwardWinner/with-simulated-input
 ;; Keywords: lisp, tools, extensions

--- a/with-simulated-input.el
+++ b/with-simulated-input.el
@@ -180,7 +180,7 @@ in `progn'."
                                    stringp symbolp]
                               def-body)))
   (if (and (symbolp keys) keys)
-      `(progn
+      `(when ,keys
          (cl-check-type ,keys string)
          (with-simulated-input-1
           (lambda ()

--- a/with-simulated-input.el
+++ b/with-simulated-input.el
@@ -177,13 +177,14 @@ in `progn'."
                                    ([&not symbolp] &rest &or stringp def-form)
                                    form]
                               def-body)))
-  (if (symbolp (car keys))
-      (cl-callf list keys)
+  ;; (...) is supposed to be like '(), unless it is a function call or
+  ;; quote/list expression
+  (when (and (listp keys) (not (symbolp (car keys))))
     (setq keys `(quote ,keys)))
   (pcase keys
     (`(quote ,x) (setq keys (cl-loop for key in x collect (if (consp key) `',key key))))
-    (`(list . keys) (cl-callf cdr keys))
-    ((guard (not (listp keys))) (cl-callf list keys)))
+    (`(list . ,keys) (cl-callf cdr keys))
+    ((or (guard (not (listp keys))) (guard (symbolp (car keys)))) (cl-callf list keys)))
   `(with-simulated-input--1
     (lambda ()
       ,@body)

--- a/with-simulated-input.el
+++ b/with-simulated-input.el
@@ -173,8 +173,8 @@ are propagated normally.
 
 The return value is the last form in BODY, as if it was wrapped
 in `progn'."
-  (declare (indent 1) (debug ([&or ("quote" (&rest &or stringp symbolp def-form))
-                                   (&rest &or stringp symbolp def-form)]
+  (declare (indent 1) (debug ([&or ("quote" (&rest &or stringp def-form))
+                                   (&rest &or stringp def-form)]
                               def-body)))
   (pcase keys
     (`(quote ,x) (setq keys x))
@@ -182,7 +182,7 @@ in `progn'."
   `(with-simulated-input-1
     (lambda ()
       ,@body)
-    ,@(cl-loop for key in keys collect (if (consp key) `(lambda () ,key) key))))
+    ,@(cl-loop for key in keys collect (if (stringp key) key `(lambda () ,key)))))
 
 (defvar wsi-simulated-idle-time nil
   "The current simulated idle time.

--- a/with-simulated-input.el
+++ b/with-simulated-input.el
@@ -98,7 +98,8 @@ to check."
        do (cl-return-from findkey bind))
    finally do (error "Could not find an unbound key with the specified modifiers")))
 
-(defun with-simulated-input--1 (main &rest keys)
+;;;###autoload
+(defun with-simulated-input-1 (main &rest keys)
   "Internal `with-simulated-input' helper.
 KEYS is a keylist as can be passed to that function (except that
 only a list is allowed, and forms must be functions) and MAIN is
@@ -185,7 +186,7 @@ in `progn'."
     (`(quote ,x) (setq keys (cl-loop for key in x collect (if (consp key) `',key key))))
     (`(list . ,keys) (cl-callf cdr keys))
     ((or (guard (not (listp keys))) (guard (symbolp (car keys)))) (cl-callf list keys)))
-  `(with-simulated-input--1
+  `(with-simulated-input-1
     (lambda ()
       ,@body)
     ,@(cl-loop for key in keys collect (pcase key

--- a/with-simulated-input.el
+++ b/with-simulated-input.el
@@ -123,7 +123,7 @@ the body form as a function."
         (interactive)
         (condition-case data
             (funcall (pop actions))
-          (t (throw error-sym data)))))
+          (error (throw error-sym data)))))
     (catch result-sym
       ;; Signals are not passed trough `read-from-minibuffer'.
       (let ((err (catch error-sym

--- a/with-simulated-input.el
+++ b/with-simulated-input.el
@@ -176,7 +176,7 @@ are propagated normally.
 The return value is the last form in BODY, as if it was wrapped
 in `progn'."
   (declare (indent 1) (debug ([&or ("quote" (&rest &or stringp def-form))
-                                   (&rest &or stringp def-form)
+                                   (&rest &or stringp form)
                                    stringp symbolp]
                               def-body)))
   (if (and (symbolp keys) keys)

--- a/with-simulated-input.el
+++ b/with-simulated-input.el
@@ -134,7 +134,10 @@ are propagated normally.
 
 The return value is the last form in BODY, as if it was wrapped
 in `progn'."
-  (declare (indent 1))
+  (declare (indent 1) (debug ([&or ("quote" (&rest &or stringp def-form))
+                                   (&rest &or stringp def-form)
+                                   stringp]
+                              def-body)))
   (pcase keys
     (`(quote ,x) (setq keys x))
     ((guard (not (listp keys))) (cl-callf list keys)))


### PR DESCRIPTION
Rewrite `with-simulated-input` to expand more cleanly: return `lambda` forms so
that correct closures are created at run-time, and make it hygienic by using
`make-symbol` for local variables.

This should fix all current issues, but the list interpolation feature will have
to be sacrificed, since there is no way to implement it properly without
resorting to closure hacks (I don't believe it to be useful, though, since users
could just use `execute-kbd-macro` in their forms to get the same effect).

```emacs-lisp
(with-simulated-input ("hello SPC" (insert "world") "RET") (read-string))
```

is now the canonical form, but for backwards compatibility, quoted lists are
handled the same way.

Using LOOPFUNC is impossible if interspersed forms are to be allowed.

As a bonus, `with-simulated-input` can now be stepped trough using `edebug`.

Drop `wsi-make-closure`/`wsi-current-lexical-environment`.