### PR TITLE
Clean up idle time advice

### DIFF
--- a/tests/test-with-simulated-input.el
+++ b/tests/test-with-simulated-input.el
@@ -238,10 +238,10 @@ Note that there are multiple ways to represent a time, so
     (expect 'idle-canary :to-have-been-called))
 
   (it "should simulate the appropriate value for `(current-idle-time)'"
-    (spy-on 'current-idle-time@simulate-idle-time :and-call-through)
+    (spy-on 'with-simulated-input--current-idle-time-a :and-call-through)
     (run-with-idle-timer 1 nil 'idle-canary)
     (wsi-simulate-idle-time 2)
-    (expect 'current-idle-time@simulate-idle-time :to-have-been-called)
+    (expect 'with-simulated-input--current-idle-time-a :to-have-been-called)
     (expect canary-idle-time :to-be-truthy)
     (expect (time-equal-p canary-idle-time (seconds-to-time 1))))
 

--- a/with-simulated-input.el
+++ b/with-simulated-input.el
@@ -268,7 +268,7 @@ been simulated so far. For example, if an idle time is set to run
 every 5 seconds while idle, then on its first run, this will be
 set to 5 seconds, then 10 seconds the next time, and so on.")
 
-(defun current-idle-time@simulate-idle-time (orig-fun &rest args)
+(defun with-simulated-input--current-idle-time-a (orig-fun &rest args)
   "Return the faked value while simulating idle time.
 
 While executing `wsi-simulate-idle-time', this advice causes the
@@ -277,7 +277,8 @@ simulated idle time to be returned instead of the real value."
       (when (time-less-p (seconds-to-time 0) wsi-simulated-idle-time)
         wsi-simulated-idle-time)
     (apply orig-fun args)))
-(advice-add 'current-idle-time :around 'current-idle-time@simulate-idle-time)
+(advice-add 'current-idle-time
+            :around #'with-simulated-input--current-idle-time-a)
 
 (cl-defun wsi-simulate-idle-time (&optional secs actually-wait)
   "Run all idle timers with delay less than SECS.
@@ -347,7 +348,8 @@ add other idle timers."
 
 (defun with-simulated-input-unload-function ()
   "Unload the `with-simulated-input' library."
-  (advice-remove 'current-idle-time 'current-idle-time@simulate-idle-time))
+  (advice-remove 'current-idle-time
+                 #'with-simulated-input--current-idle-time-a))
 
 (provide 'with-simulated-input)
 

--- a/with-simulated-input.el
+++ b/with-simulated-input.el
@@ -345,6 +345,10 @@ add other idle timers."
      (sleep-for (float-time (time-subtract stop-time
                                            wsi-simulated-idle-time))))))
 
+(defun with-simulated-input-unload-function ()
+  "Unload the `with-simulated-input' library."
+  (advice-remove 'current-idle-time 'current-idle-time@simulate-idle-time))
+
 (provide 'with-simulated-input)
 
 ;;; with-simulated-input.el ends here


### PR DESCRIPTION
- Add an `unload-function`, so that `M-x unload-feature` `with-simulated-input`
  causes the `current-idle-time` advice to be removed
- Rename `current-idle-time@simulated-idle-time` ->
  `with-simulated-input--current-idle-time-a`, adding the package prefix
- `#'` uses of it in `advice-add`